### PR TITLE
Bug/insert recipe asks for url twice

### DIFF
--- a/org-chef-utils.el
+++ b/org-chef-utils.el
@@ -30,7 +30,7 @@
 
 ;;; Commentary:
 
-;; Utilitiy functions for org-chef.
+;; Utility functions for org-chef.
 
 ;;; Code:
 

--- a/org-chef.el
+++ b/org-chef.el
@@ -103,11 +103,10 @@
    ((org-chef-match-url "chefkoch.de" URL) (org-chef-chef-koch-fetch URL))))
 
 
-(defun org-chef-insert-recipe ()
+(defun org-chef-insert-recipe (URL)
   "Prompt for a recipe URL, and then insert the recipe at point."
-  (interactive)
-  (let ((URL (read-string "Recipe URL: ")))
-    (org-chef-recipe-insert-org (org-chef-fetch-recipe (read-string "Recipe URL: ")))))
+  (interactive "sRecipe URL: ")
+  (org-chef-recipe-insert-org (org-chef-fetch-recipe URL)))
 
 
 (defun org-chef-get-recipe-from-url ()


### PR DESCRIPTION
Hey,

Noticed that the org-chef-insert-recipe function was calling read-string twice which meant you had to enter the URL twice. Added a little fix and made it use the interactive prompt instead of calling read-string as that seemed more appropriate for this function. 

Hope that helps