### PR TITLE
Fix serious eats title extraction

### DIFF
--- a/org-chef-serious-eats.el
+++ b/org-chef-serious-eats.el
@@ -41,7 +41,7 @@
 
 (defun org-chef-serious-eats-extract-name (dom)
   "Get the name of a recipe from an seriouseats DOM."
-  (dom-text (car (dom-elements dom 'class "^recipe-title$"))))
+  (dom-text (car (dom-elements dom 'class "recipe-title"))))
 
 
 (defun org-chef-serious-eats-extract-ingredients (dom)


### PR DESCRIPTION
Before this fix:

```
ELISP> (assq 'name (org-chef-serious-eats-fetch "https://www.seriouseats.com/recipes/2014/03/tteokbokki-from-the-worlds-best-spicy-food.html"))
(name . "")
```

and after:

```
ELISP> (assq 'name (org-chef-serious-eats-fetch "https://www.seriouseats.com/recipes/2014/03/tteokbokki-from-the-worlds-best-spicy-food.html"))
(name . "Tteokbokki From 'The World's Best Spicy Food'")
```