### PR TITLE
Autoload org-chef-insert-recipe

### DIFF
--- a/org-chef.el
+++ b/org-chef.el
@@ -136,6 +136,7 @@ for more information.")
       (org-chef-wordpress-fetch URL))))
 
 
+;;;###autoload
 (defun org-chef-insert-recipe (URL)
   "Prompt for a recipe URL, and then insert the recipe at point."
   (interactive "sRecipe URL: ")


### PR DESCRIPTION
This allows lazy-loading org-chef with (use-package org-chef :defer t) but still calling org-chef-insert-recipe when needed.