### PR TITLE
Require gnutls

### DIFF
--- a/org-chef-utils.el
+++ b/org-chef-utils.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'cl-macs)
+(require 'gnutls)
 
 (defun org-chef-remove-empty-strings (lst)
   "Filter out any empty strings in a list of strings (LST)."


### PR DESCRIPTION
Recipe fetching will fail with `org-chef-wordpress-fetch: Symbol’s value as variable is void:
gnutls-algorithm-priority` if gnutls is not loaded.