### PR TITLE
Add support for BBC Good Food recipes

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,6 +104,8 @@
   - https://www.finecooking.com/
   - Any recipe site based on wordpress
   - https://taste.com.au/
+  - https://www.bbc.co.uk/food/
+  - https://www.bbcgoodfood.com/
 
 * Contributing
 

--- a/org-chef-bbc-good-food.el
+++ b/org-chef-bbc-good-food.el
@@ -1,0 +1,63 @@
+
+;;; org-chef-bbc-good-food.el --- Functions for fetching recipes from bbcgoodfood.com  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 Calvin Beck
+
+;; Author:  Calvin Beck <hobbes@ualberta.ca>
+;; URL: https://github.com/Chobbes/org-chef
+;; Created: 2018
+
+;; Copyright 2018 Calvin Beck
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; Functions for fetching information from www.bbcgoodfood.com
+(require 'org-chef-utils)
+(require 'org-chef-json-ld)
+
+(defun org-chef-bbc-good-food-clean-direction (direction)
+  "Removes <p> tags from a single direction string"
+  (replace-regexp-in-string "</?p>" "" direction))
+
+(defun org-chef-bbc-good-food-fetch (url)
+  "Given a bbcgoodfood.com URL, retrieve the recipe information.
+
+This returns an alist with the following keys:
+
+- name
+- ingredients
+- servings
+- prep-time
+- cook-time
+- ready-in
+- directions
+- source-url"
+  (let* ((result (org-chef-json-ld-fetch url))
+         (directions (assoc 'directions result))
+         (cleaned (mapcar #'org-chef-bbc-good-food-clean-direction (cdr directions))))
+    (setf (cdr directions) cleaned)
+    result))
+
+
+(provide 'org-chef-bbc-good-food)
+;;; org-chef-bbc-good-food.el ends here

--- a/org-chef.el
+++ b/org-chef.el
@@ -59,6 +59,7 @@
 (require 'org-chef-wordpress)
 (require 'org-chef-taste)
 (require 'org-chef-bbc-food)
+(require 'org-chef-bbc-good-food)
 
 
 (defvar org-chef-fetch-workaround
@@ -75,7 +76,7 @@ for more information.")
 (defcustom org-chef-prefer-json-ld nil
   "Prefer JSON-LD extractor over custom extractor. This is for testing the JSON-LD functionality."
   :type 'boolean)
-  
+
 (defun org-chef-recipe-insert-org (recipe)
   "Insert a RECIPE as an ‘org-mode’ heading."
   (org-insert-heading)
@@ -132,6 +133,7 @@ for more information.")
    ((org-chef-match-url "finecooking.com" URL) (org-chef-fine-cooking-fetch URL))
    ((org-chef-match-url "taste.com.au" URL) (org-chef-taste-fetch URL))
    ((org-chef-match-url "bbc.co.uk/food/" URL) (org-chef-bbc-food-fetch URL))
+   ((org-chef-match-url "bbcgoodfood.com" URL) (org-chef-bbc-good-food-fetch URL))
    (t nil)))
 
 


### PR DESCRIPTION
This adds support for [BBC Good Food](https://www.bbcgoodfood.com/) recipes (which is a different site to [BBC Food](https://www.bbc.co.uk/food/)!).

I have added the file `org-chef-bbc-good-food.el` which defines two functions and essentially just calls `org-chef-json-ld-fetch` and cleans up the directions (removing some `<p>` tags).