### PR TITLE
Add support for recipes from jamieoliver.com

### DIFF
--- a/org-chef-jamie-oliver.el
+++ b/org-chef-jamie-oliver.el
@@ -1,0 +1,70 @@
+
+;;; org-chef-jamie-oliver.el --- Functions for fetching recipes from jamieoliver.com.  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 Calvin Beck
+
+;; Author:  Calvin Beck <hobbes@ualberta.ca>
+;; URL: https://github.com/Chobbes/org-chef
+;; Created: 2018
+
+;; Copyright 2018 Calvin Beck
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; Functions for fetching information from bbc.co.uk/food/
+(require 'org-chef-utils)
+(require 'dom)
+(require 'org-chef-json-ld)
+
+
+(defun org-chef-jamie-oliver-clean-direction (xml)
+  "Parses dom in direction string, returning a list of directions"
+  (let ((direction-dom  (org-chef-string-to-dom xml)))
+    (if direction-dom
+        (dom-strings direction-dom)
+      (split-string xml "[
+]+"))))
+
+
+(defun org-chef-jamie-oliver-fetch (url)
+  "Given a jamieoliver.com URL, retrieve the recipe information.
+
+This returns an alist with the following keys:
+
+- name
+- ingredients
+- servings
+- prep-time
+- cook-time
+- ready-in
+- directions
+- source-url"
+  (let* ((result (org-chef-json-ld-fetch url))
+         (directions (assoc 'directions result))
+         (cleaned (mapcan #'org-chef-jamie-oliver-clean-direction (cdr directions))))
+    (setf (cdr directions) cleaned)
+    result))
+
+
+(provide 'org-chef-jamie-oliver)
+;;; org-chef-jamie-oliver.el ends here

--- a/org-chef-utils.el
+++ b/org-chef-utils.el
@@ -36,6 +36,7 @@
 
 (require 'cl-macs)
 (require 'gnutls)
+(require 'dom)
 
 (defun org-chef-remove-empty-strings (lst)
   "Filter out any empty strings in a list of strings (LST)."
@@ -73,6 +74,12 @@ This is a wrapper for url-retrieve-synchronously, which primarily serves to impl
                 gnutls-algorithm-priority)))
 
     (url-retrieve-synchronously url)))
+
+
+(defun org-chef-string-to-dom (xml)
+  (with-temp-buffer
+    (insert xml)
+    (xml-parse-region (point-min) (point-max))))
 
 
 (provide 'org-chef-utils)

--- a/org-chef.el
+++ b/org-chef.el
@@ -60,6 +60,7 @@
 (require 'org-chef-taste)
 (require 'org-chef-bbc-food)
 (require 'org-chef-bbc-good-food)
+(require 'org-chef-jamie-oliver)
 
 
 (defvar org-chef-fetch-workaround
@@ -134,6 +135,7 @@ for more information.")
    ((org-chef-match-url "taste.com.au" URL) (org-chef-taste-fetch URL))
    ((org-chef-match-url "bbc.co.uk/food/" URL) (org-chef-bbc-food-fetch URL))
    ((org-chef-match-url "bbcgoodfood.com" URL) (org-chef-bbc-good-food-fetch URL))
+   ((org-chef-match-url "jamieoliver.com" URL) (org-chef-jamie-oliver-fetch URL))
    (t nil)))
 
 


### PR DESCRIPTION
This site contains JSON-LD, but the directions often contain html markup, or otherwise are separated by newlines, which this pull request cleans up.

Also adds a helper function `org-chef-string-to-dom` which parses an xml string.