### PR TITLE
Add support for RecipeTin Eats recipes

### DIFF
--- a/org-chef-recipetin-eats.el
+++ b/org-chef-recipetin-eats.el
@@ -1,0 +1,114 @@
+
+;;; org-chef-recipetin-eats.el --- Functions for fetching recipes from recipetineats.com  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 Calvin Beck
+
+;; Author:  Calvin Beck <hobbes@ualberta.ca>
+;; URL: https://github.com/Chobbes/org-chef
+;; Created: 2018
+
+;; Copyright 2018 Calvin Beck
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; Functions for fetching information from www.recipetineats.com
+(require 'org-chef-utils)
+(require 'dom)
+
+
+(defun org-chef-recipetin-eats-extract-name (dom)
+  "Get the name of a recipe from a recipetin-eats DOM."
+  (dom-text (car (dom-by-class dom "^wprm-recipe-name"))))
+
+
+(defun org-chef-recipetin-eats-extract-ingredients (dom)
+  "Get the ingredients for a recipe from a RecipeTin Eats DOM."
+  (mapcar #'(lambda (n)
+              (let ((notes (dom-text (dom-by-class n "wprm-recipe-ingredient-notes"))))
+                (concat (dom-text (dom-by-class n "wprm-recipe-ingredient-amount"))
+                        " "
+                        (dom-text (dom-by-class n "wprm-recipe-ingredient-name"))
+                        (if (or (zerop (length notes))
+                                (= (elt notes 0) ?,))
+                            "" ", ")
+                        notes)))
+          (dom-by-class dom "^wprm-recipe-ingredient$")))
+
+
+(defun org-chef-recipetin-eats-extract-servings (dom)
+  "Get the number of servings for a recipe from a RecipeTin Eats DOM."
+  (dom-attr (car (dom-by-class dom "wprm-recipe-container")) 'data-servings))
+
+
+(defun org-chef-recipetin-eats-extract-prep-time (dom)
+  "Get the amount of prep-time for a recipe from a RecipeTin Eats DOM."
+  (let ((span (nth 1 (dom-children
+                      (car (dom-by-class dom "wprm-recipe-prep-time-container"))))))
+    (org-chef-join (dom-strings span) "")))
+
+
+(defun org-chef-recipetin-eats-extract-cook-time (dom)
+  "Get the amount of cook-time for a recipe from a RecipeTin Eats DOM."
+  (let ((span (nth 1 (dom-children
+                      (car (dom-by-class dom "wprm-recipe-cook-time-container"))))))
+    (org-chef-join (dom-strings span) "")))
+
+
+(defun org-chef-recipetin-eats-extract-ready-in (dom)
+  "Get the total amount of time for a recipe from a RecipeTin Eats DOM."
+  (let ((span (nth 1 (dom-children
+                      (car (dom-by-class dom "wprm-recipe-total-time-container"))))))
+    (org-chef-join (dom-strings span) "")))
+
+
+(defun org-chef-recipetin-eats-extract-directions (dom)
+  "Get the directions for a recipe from a RecipeTin Eats DOM."
+  (org-chef-remove-empty-strings (mapcar #'(lambda (n) (string-trim (dom-texts n))) (dom-by-class dom  "^wprm-recipe-instruction$"))))
+
+
+(defun org-chef-recipetin-eats-fetch (url)
+  "Given a recipetineats.com URL, retrieve the recipe information.
+
+This returns an alist with the following keys:
+
+- name
+- ingredients
+- servings
+- prep-time
+- cook-time
+- ready-in
+- directions
+- source-url"
+  (let ((dom (org-chef-url-retrieve-dom url)))
+    `((name . ,(org-chef-recipetin-eats-extract-name dom))
+      (ingredients . ,(org-chef-recipetin-eats-extract-ingredients dom))
+      (servings . ,(org-chef-recipetin-eats-extract-servings dom))
+      (prep-time . ,(org-chef-recipetin-eats-extract-prep-time dom))
+      (cook-time . ,(org-chef-recipetin-eats-extract-cook-time dom))
+      (ready-in . ,(org-chef-recipetin-eats-extract-ready-in dom))
+      (directions . ,(org-chef-recipetin-eats-extract-directions dom))
+      (source-url . ,url))))
+
+
+(provide 'org-chef-recipetin-eats)
+;;; org-chef-recipetin-eats.el ends here

--- a/org-chef-utils.el
+++ b/org-chef-utils.el
@@ -82,5 +82,20 @@ This is a wrapper for url-retrieve-synchronously, which primarily serves to impl
     (xml-parse-region (point-min) (point-max))))
 
 
+(defun org-chef-url-retrieve-dom (url)
+  "Fetch URL synchronously, and parse into a DOM structure"
+  (with-current-buffer (org-chef-url-retrieve-synchronously url)
+    (goto-char (point-min))
+    (search-forward "\n\n")             ; skip past HTTP headers
+    (let ((result (libxml-parse-html-region (point) (point-max))))
+      (kill-buffer)                     ; don't leak buffer
+      result)))
+
+
+(defun org-chef-join (strings separator)
+  "Joins a list of strings using a separator"
+  (mapconcat #'identity strings separator))
+
+
 (provide 'org-chef-utils)
 ;;; org-chef-utils.el ends here

--- a/org-chef.el
+++ b/org-chef.el
@@ -61,6 +61,7 @@
 (require 'org-chef-bbc-food)
 (require 'org-chef-bbc-good-food)
 (require 'org-chef-jamie-oliver)
+(require 'org-chef-recipetin-eats)
 
 
 (defvar org-chef-fetch-workaround
@@ -136,6 +137,7 @@ for more information.")
    ((org-chef-match-url "bbc.co.uk/food/" URL) (org-chef-bbc-food-fetch URL))
    ((org-chef-match-url "bbcgoodfood.com" URL) (org-chef-bbc-good-food-fetch URL))
    ((org-chef-match-url "jamieoliver.com" URL) (org-chef-jamie-oliver-fetch URL))
+   ((org-chef-match-url "recipetineats.com" URL) (org-chef-recipetin-eats-fetch URL))
    (t nil)))
 
 


### PR DESCRIPTION
Based on existing wordpress support. Also adds two utility functions, `org-chef-url-retrieve-dom` and `org-chef-join`.

(BTW it would be worth refactoring the other files to also use `org-chef-url-retrieve-dom`, as it prevents leaking buffers.)