### PR TITLE
Add autoload magic comment to org-chef-get-recipe-from-url

### DIFF
--- a/org-chef.el
+++ b/org-chef.el
@@ -157,6 +157,7 @@ for more information.")
   (org-chef-recipe-insert-org (org-chef-fetch-recipe URL)))
 
 
+;;;###autoload
 (defun org-chef-get-recipe-from-url ()
   "Prompt for a recipe URL, and return the ‘org-mode’ string."
   (let ((URL (read-string "Recipe URL: ")))


### PR DESCRIPTION
This should allow the `org-capture` snippet given in the README to work without `(require 'org-chef)`.