### PR TITLE
Initial implementation of org-chef-edit-servings

### DIFF
--- a/README.org
+++ b/README.org
@@ -83,6 +83,12 @@
   You can also insert a recipe at point using the command
   ~org-chef-insert-recipe~.
 
+* Editing recipes
+
+  You can change the number of servings in a recipe using the
+  command ~org-chef-edit-servings~. This will automatically update
+  the ingredients list to match.
+
 * Supported Sites
 
   The following websites should support recipe extraction:

--- a/org-chef-edit.el
+++ b/org-chef-edit.el
@@ -1,0 +1,89 @@
+;;; org-chef-edit.el --- Cookbook and recipe management with org-mode.  -*- lexical-binding: t; -*-
+
+;; Copyright 2021 Alexander Huntley
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; Provides commands to modify the number of servings in a recipe.
+
+;;; Code:
+
+
+(defun org-chef-edit--do-replace (multiplier)
+  "Replaces all numbers (in a variety of formats) in the region,
+multiplying them all by MULTIPLIER"
+  (save-excursion
+    (while (re-search-forward
+            "\\([0-9]+\\)?\\([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]\\)\\|\\([0-9]+\\)/\\([0-9]+\\)\\|\\([0-9]+\\)" (mark) t)
+      (cond
+       ;; Unicode vulgar/mixed fractions
+       ((match-string 2)
+        (let* ((char (elt (match-string 2) 0))
+               (frac (get-char-code-property char 'numeric-value))
+               (int (if (match-string 1) (string-to-number (match-string 1)) 0))
+               (original (+ int frac)))
+          (replace-match (format "%.3g" (* multiplier original)))))
+       ;; ASCII fractions
+       ((match-string 3)
+        (let ((original (/ (float (string-to-number (match-string 3)))
+                           (float (string-to-number (match-string 4))))))
+          (replace-match (format "%.3g" (* multiplier original)))))
+       ;; simple decimals
+       ((match-string 5)
+        (replace-match
+         (format "%.3g" (* multiplier (string-to-number
+                                       (match-string 5))))))))))
+
+
+(defun org-chef-edit--parse-servings (string)
+  "Finds all integers in STRING, and computes their mean"
+  (let ((ints (mapcar #'string-to-number (org-chef-regexp-matches "[0-9]+" string))))
+    (/ (reduce #'+ ints) (length ints))))
+
+
+;;;###autoload
+(defun org-chef-edit-servings (desired)
+  "Changes the serving count of an org-chef recipe entry to DESIRED, also modifying
+the quantities inside the ingredients list."
+  (interactive "*sChange servings to: ")
+  (save-excursion
+    (condition-case nil
+        (while (not (org-entry-get nil "servings"))
+          (outline-up-heading 1))
+      (error (error "Could not find recipe with \"servings\" property")))
+    (outline-show-subtree)
+    (save-excursion
+      (let* ((servings (org-chef-edit--parse-servings
+                        (org-entry-get nil "servings")))
+             (desired (if (numberp desired) desired
+                        (org-chef-edit--parse-servings desired)))
+             (multiplier (/ (float desired) (float servings))))
+        (outline-next-heading)
+        (outline-mark-subtree)
+        (next-line)
+        (org-chef-edit--do-replace multiplier)))
+    (org-entry-put nil "servings" (format "%s" desired))))
+
+
+(provide 'org-chef-edit)
+;;; org-chef-edit.el ends here

--- a/org-chef-utils.el
+++ b/org-chef-utils.el
@@ -97,5 +97,18 @@ This is a wrapper for url-retrieve-synchronously, which primarily serves to impl
   (mapconcat #'identity strings separator))
 
 
+;; Adapted from https://emacs.stackexchange.com/a/7150
+(defun org-chef-regexp-matches (regexp string)
+  "Get a list of all regexp matches in a string"
+  (save-match-data
+    (let ((pos 0) stop matches)
+      (while (and (not stop) (string-match regexp string pos))
+        (push (match-string 0 string) matches)
+        (when (= (match-end 0) pos)
+          (setq stop t))
+        (setq pos (match-end 0)))
+      (nreverse matches))))
+
+
 (provide 'org-chef-utils)
 ;;; org-chef-utils.el ends here

--- a/org-chef.el
+++ b/org-chef.el
@@ -41,6 +41,8 @@
 
 
 (require 'org-chef-utils)
+(require 'org-chef-edit)
+
 (require 'org-chef-24kitchen)
 (require 'org-chef-all-recipes)
 (require 'org-chef-json-ld)


### PR DESCRIPTION
Adds the command `org-chef-edit-servings`, which changes the number of servings in the recipe under point and also updates all the quantities under the Ingredients heading.

Useful for meal planning and probably other things...