### PR TITLE
Fix regexp parsing of float ingredients when editing servings

### DIFF
--- a/org-chef-edit.el
+++ b/org-chef-edit.el
@@ -36,7 +36,7 @@
 multiplying them all by MULTIPLIER"
   (save-excursion
     (while (re-search-forward
-            "\\([0-9]+\\)?\\([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]\\)\\|\\([0-9]+\\)/\\([0-9]+\\)\\|\\([0-9]+\\)" (mark) t)
+            "\\([0-9]+\\)?\\([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]\\)\\|\\([0-9]+\\)/\\([0-9]+\\)\\|\\([0-9]+\\(?:\\.[0-9]+\\)?\\)" (mark) t)
       (cond
        ;; Unicode vulgar/mixed fractions
        ((match-string 2)


### PR DESCRIPTION
When editing servings for a recipe that has ingredients in a decimal point format, such as 1.5, etc..., the serving multiplication multiplies each integer separately. So for halving the servings the result was: 0.5.2.5. 

The regexp modification fixes this.